### PR TITLE
Renamed `sigmoid` to `logistic`

### DIFF
--- a/dist/dist.toml
+++ b/dist/dist.toml
@@ -209,7 +209,7 @@ test_cases = [
 	{ n = 6, a = -1, b = 1, ratio=10, expected = [-1, -0.99737108303933162, -0.95575857698159284, 0.95575857698159284, 0.99737108303933162, 1] },
 ]
 
-[sigmoid]
+[logistic]
 test_cases = [
 	{ n = 0, a = -1, b = 1, steepness=0.1, expected = [] },
 	{ n = 0, a = -1, b = 1, steepness=0.25, expected = [] },
@@ -262,7 +262,7 @@ test_cases = [
 	{ n = 6, a = -1, b = 1, steepness=10, expected = [-0.99990920426259513, -0.99505475368673045, -0.76159415595576489, 0.76159415595576489, 0.99505475368673045, 0.99990920426259513] },
 ]
 
-[sigmoid_stretched]
+[logistic_stretched]
 test_cases = [
 	{ n = 0, a = -1, b = 1, steepness=0.1, expected = [] },
 	{ n = 0, a = -1, b = 1, steepness=0.25, expected = [] },

--- a/dist/generate.py
+++ b/dist/generate.py
@@ -69,12 +69,12 @@ def ellipse_proj(n, ratio):
 	return [0] if n == 1 else [mp.sign(2*k+1 - n) / mp.sqrt(1 + (mp.tan(mp.pi * mp.mpf(k) / (n-1)) / ratio) ** 2) for k in range(n)]
 
 
-def sigmoid(n, steepness):
+def logistic(n, steepness):
 	return [0] if n == 1 else [2 / (1 + mp.exp(-steepness * (2 * mp.mpf(k) / (n-1) - 1))) - 1 for k in range(n)]
 
 
-def sigmoid_stretched(n, steepness):
-	return stretched(sigmoid(n, steepness))
+def logistic_stretched(n, steepness):
+	return stretched(logistic(n, steepness))
 
 
 def erf(n, steepness):
@@ -89,7 +89,7 @@ def generate_test_cases():
 	mapping_intervals_section = 'mapping_intervals = [\n' + '\n'.join([f'\t[{i[0]}, {i[1]}],' for i in mapping_intervals]) + '\n]'
 
 	functions = [uniform, chebyshev, chebyshev_stretched, chebyshev_ellipse, chebyshev_ellipse_stretched,
-				circle_proj, ellipse_proj, sigmoid, sigmoid_stretched, erf, erf_stretched]
+				circle_proj, ellipse_proj, logistic, logistic_stretched, erf, erf_stretched]
 	sections = []
 
 	for func in functions:


### PR DESCRIPTION
### Types of changes
- Refactoring, reformatting, cleanup

Related: #1

### Description
Renamed `sigmoid` to `logistic` for a more accurate (literal) match to the concept.

The term `sigmoid` is often used to refer to the logistic function, but this is not entirely accurate because it covers a large variety of functions (e.g. erf, tanh, arctan).

**Examples:**
![examples: erf, tanh, arctan and others](https://upload.wikimedia.org/wikipedia/commons/6/6f/Gjl-t%28x%29.svg)

In this case, the term `logistic` is more appropriate.

**Standard logistic function:**
![standard logistic function](https://github.com/user-attachments/assets/8c5d3bbe-af88-4ad1-93b2-2dba47c39b63)

### Future improvements
The change eliminates semantic ambiguities, allowing more sigmoid functions to be implemented in the future.

### External links
https://en.wikipedia.org/wiki/Sigmoid_function
https://en.wikipedia.org/wiki/Logistic_function

https://ru.wikipedia.org/wiki/Сигмоида
https://ru.wikipedia.org/wiki/Логистическое_уравнение