### PR TITLE
Added `quadratic` and `cubic` distributions data

### DIFF
--- a/dist/dist.toml
+++ b/dist/dist.toml
@@ -17,6 +17,28 @@ test_cases = [
 	{ n = 6, a = -1, b = 1, expected = [-1, -0.6, -0.2, 0.2, 0.6, 1] },
 ]
 
+[quadratic]
+test_cases = [
+	{ n = 0, a = -1, b = 1, expected = [] },
+	{ n = 1, a = -1, b = 1, expected = [0] },
+	{ n = 2, a = -1, b = 1, expected = [-1, 1] },
+	{ n = 3, a = -1, b = 1, expected = [-1, 0, 1] },
+	{ n = 4, a = -1, b = 1, expected = [-1, -0.55555555555555556, 0.55555555555555556, 1] },
+	{ n = 5, a = -1, b = 1, expected = [-1, -0.75, 0, 0.75, 1] },
+	{ n = 6, a = -1, b = 1, expected = [-1, -0.84, -0.36, 0.36, 0.84, 1] },
+]
+
+[cubic]
+test_cases = [
+	{ n = 0, a = -1, b = 1, expected = [] },
+	{ n = 1, a = -1, b = 1, expected = [0] },
+	{ n = 2, a = -1, b = 1, expected = [-1, 1] },
+	{ n = 3, a = -1, b = 1, expected = [-1, 0, 1] },
+	{ n = 4, a = -1, b = 1, expected = [-1, -0.48148148148148148, 0.48148148148148148, 1] },
+	{ n = 5, a = -1, b = 1, expected = [-1, -0.6875, 0, 0.6875, 1] },
+	{ n = 6, a = -1, b = 1, expected = [-1, -0.792, -0.296, 0.296, 0.792, 1] },
+]
+
 [chebyshev]
 test_cases = [
 	{ n = 0, a = -1, b = 1, expected = [] },

--- a/dist/generate.py
+++ b/dist/generate.py
@@ -45,6 +45,14 @@ def uniform(n):
 	return [0] if n == 1 else [2 * mp.mpf(k) / (n-1) - 1 for k in range(n)]
 
 
+def quadratic(n):
+	return [(x + 1)**2 - 1 if x <= 0 else -(x - 1)**2 + 1 for x in uniform(n)]
+
+
+def cubic(n):
+	return [-0.5 * x**3 + 1.5 * x for x in uniform(n)]
+
+
 def chebyshev(n):
 	return [-mp.cos((2*k - 1) * mp.pi / (2*n)) for k in range(1, n + 1)]
 
@@ -88,7 +96,7 @@ def erf_stretched(n, steepness):
 def generate_test_cases():
 	mapping_intervals_section = 'mapping_intervals = [\n' + '\n'.join([f'\t[{i[0]}, {i[1]}],' for i in mapping_intervals]) + '\n]'
 
-	functions = [uniform, chebyshev, chebyshev_stretched, chebyshev_ellipse, chebyshev_ellipse_stretched,
+	functions = [uniform, quadratic, cubic, chebyshev, chebyshev_stretched, chebyshev_ellipse, chebyshev_ellipse_stretched,
 				circle_proj, ellipse_proj, logistic, logistic_stretched, erf, erf_stretched]
 	sections = []
 


### PR DESCRIPTION
### Types of changes
- Feature

Related: #1 #3

### Description
Added `quadratic` and `cubic` distributions data.

The **"quadratic" distribution** is given by:

$$
\mathrm{quadratic}(x) =
\begin{cases}
(x+1)^2 - 1, & x \leq 0 \\
-(x-1)^2 + 1, & x > 0
\end{cases}
$$

The **"cubic" distribution** is given by:

$$
\mathrm{cubic}(x) = -0.5x^3 + 1.5x
$$

The distribution of points is generated by applying these functions to the uniformly distributed points on the $[-1, 1]$ segment.

You can interact with these distributions on this Desmos graph: https://www.desmos.com/calculator/qdse58hzhp.