### PR TITLE
Refined epsilon handling: consider boundary values as equal

### DIFF
--- a/misc/generate.py
+++ b/misc/generate.py
@@ -86,7 +86,7 @@ def barycentric(X, Y, xx, dist, epsilon):
 	for k in range(n):
 		for i, xi in enumerate(xx):
 			xdiff = xi - X[k]
-			if mp.fabs(xdiff) < epsilon:
+			if mp.fabs(xdiff) <= epsilon:
 				exact[i] = k
 			else:
 				temp = c[k] / xdiff

--- a/spline/generate_step.py
+++ b/spline/generate_step.py
@@ -85,10 +85,10 @@ def generate_test_case(params):
 	for x in xx:
 		while cur_segment + 1 < len(X) - 1 and X[cur_segment + 1] <= x:
 			cur_segment += 1
-		if mp.fabs(x - X[cur_segment]) < float64_eps:
+		if mp.fabs(x - X[cur_segment]) <= float64_eps:
 			yy.append(Y[cur_segment])
 			continue
-		if mp.fabs(x - X[cur_segment+1]) < float64_eps:
+		if mp.fabs(x - X[cur_segment+1]) <= float64_eps:
 			yy.append(Y[cur_segment+1])
 			continue
 		match type:


### PR DESCRIPTION
### Types of changes
- Something between a small fix and a feature, maybe refactoring

Related: #11 #12

### Description
Changed epsilon comparisons from "<" to "<=" so values exactly at epsilon are treated as equal.